### PR TITLE
Add ability to spawn a tty using a system command

### DIFF
--- a/lib/extty.ex
+++ b/lib/extty.ex
@@ -114,11 +114,28 @@ defmodule ExTTY do
     {Elixir.IEx, :start, opts}
   end
 
+  defp shell_spawner(%{type: :muontrap, shell_opts: opts}) do
+    {__MODULE__, :spawn_muontrap, opts}
+  end
+
   defp shell_spawner(state) do
     Logger.warn(
       "[#{inspect(__MODULE__)}] unknown shell type #{inspect(state.type)} - defaulting to :elixir"
     )
 
     shell_spawner(%{state | type: :elixir})
+  end
+
+  def spawn_muontrap(opts \\ []) do
+    exec = Keyword.fetch!(opts, :exec)
+    args = Keyword.fetch!(opts, :args)
+    gl = Process.group_leader()
+
+    spawn(fn ->
+      MuonTrap.cmd(exec, args,
+        into: IO.stream(gl, :line),
+        stderr_to_stdout: true
+      )
+    end)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,8 @@ defmodule ExTTY.MixProject do
   defp deps do
     [
       {:dialyxir, "~> 1.0.0", only: :dev, runtime: false},
-      {:ex_doc, "~> 0.22", only: :docs}
+      {:ex_doc, "~> 0.22", only: :docs},
+      {:muontrap, "~> 1.0.0"}
     ]
   end
 


### PR DESCRIPTION
Allows you too do something like:
```elixir
ExTTY.start_link(handler: self(), type: :muontrap, shell_opts: [[exec: System.find_executable("bash"), args: []]])
```
