### PR TITLE
proof of concept: allow spawning remote shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,18 @@ iex()> flush()
 {:tty_data, "\e[33m2\e[0m\r\n"}
 {:tty_data, "iex(2)> "}
 ```
+
+When running in a cluster, a shell process can also be started on a remote node by
+passing the node name to the `remsh` option:
+
+```elixir
+iex(foo)1> Node.connect(:bar)
+true
+iex(foo)2> Node.list()
+[:bar]
+iex(foo)3> {:ok, tty} = ExTTY.start_link(handler: self(), remsh: :bar)
+iex(foo)4> flush()
+{:tty_data,
+ "Interactive Elixir (1.17.0-dev) - press Ctrl+C to exit (type h() ENTER for help)\r\n"}
+{:tty_data, "iex(bar)1> "}
+```

--- a/lib/extty.ex
+++ b/lib/extty.ex
@@ -34,6 +34,7 @@ defmodule ExTTY do
     handler = Keyword.get(opts, :handler)
     type = Keyword.get(opts, :type, :elixir)
     shell_opts = Keyword.get(opts, :shell_opts, [])
+    remsh = Keyword.get(opts, :remsh)
     pty = tty_pty(term: "xterm", width: 80, height: 24, modes: [echo: true, onlcr: 1])
 
     {:ok,
@@ -43,7 +44,8 @@ defmodule ExTTY do
        buf: @empty_buf,
        group: nil,
        type: type,
-       shell_opts: shell_opts
+       shell_opts: shell_opts,
+       remsh: remsh
      }, {:continue, :start_shell}}
   end
 
@@ -110,6 +112,12 @@ defmodule ExTTY do
     else
       Logger.debug("[#{inspect(__MODULE__)}] tty_data - #{inspect(str)}")
     end
+  end
+
+  defp shell_spawner(%{remsh: node} = state) when not is_nil(node) do
+    {m, f, a} = shell_spawner(%{type: state.type, shell_opts: state.shell_opts})
+
+    {:erpc, :call, [node, m, f, a]}
   end
 
   defp shell_spawner(%{type: :erlang, shell_opts: opts}) do


### PR DESCRIPTION
This allows something like

```elixir
iex> {:ok, tty} = ExTTY.start_link(handler: self(), node: :"mynode@myhost")
```

There is a problem though (therefore only as draft and no tests yet): IEx autocomplete doesn't work because it tries to run autocompletion on the wrong node (https://github.com/elixir-lang/elixir/blob/70391199a481c7d3ccb2756c99452ee7dc8ad12f/lib/iex/lib/iex/server.ex#L328-L335). Not sure how to fix this. Maybe someone else has an idea how to do this "properly".