### PR TITLE
Support Elixir 1.17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,8 +56,5 @@ workflows:
                 1.16.3-erlang-26.2.5.2-alpine-3.20.1,
                 1.15.2-erlang-26.0.2-alpine-3.18.2,
                 1.14.5-erlang-25.3.2-alpine-3.18.0,
-                1.13.4-erlang-25.3.2-alpine-3.18.0,
-                1.12.3-erlang-24.3.4.11-alpine-3.18.0,
-                1.11.4-erlang-24.3.4.11-alpine-3.18.0,
-                1.10.4-erlang-23.1.5-alpine-3.12.1
+                1.13.4-erlang-25.3.2-alpine-3.18.0
               ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 latest: &latest
-  pattern: "^1.15.2-erlang-26.*$"
+  pattern: "^1.17.*-erlang-27.*$"
 
 jobs:
   build-test:
@@ -52,6 +52,8 @@ workflows:
           matrix:
             parameters:
               tag: [
+                1.17.2-erlang-27.0.1-alpine-3.20.1,
+                1.16.3-erlang-26.2.5.2-alpine-3.20.1,
                 1.15.2-erlang-26.0.2-alpine-3.18.2,
                 1.14.5-erlang-25.3.2-alpine-3.18.0,
                 1.13.4-erlang-25.3.2-alpine-3.18.0,

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule ExTTY.MixProject do
     [
       app: :extty,
       version: @version,
-      elixir: "~> 1.10",
+      elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
       build_embedded: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
The latest Elixir changed how IEx should be started. The current way we're using is `IEx.start` which is still around in 1.17 but only arity 0. So if you include any shell_opts, the IEx session would immediately crash. If you don't use shell_opts, then things will work as normal.

This makes the needed adjustments to work with Elixir 1.17 and support shell_opts, including a change to account for .iex.exs files in the arguments