### PR TITLE
Make sure the IEx server is cleaned up

### DIFF
--- a/lib/extty.ex
+++ b/lib/extty.ex
@@ -96,6 +96,13 @@ defmodule ExTTY do
     {:noreply, %{state | buf: new_buf}}
   end
 
+  @impl GenServer
+  def terminate(reason, state) do
+    # The `IEx.Server` and `IEx.Evaluator` don't go away with a simple `:normal` exit.
+    Process.exit(state.group, :kill)
+    :ok
+  end
+
   defp start_shell(state) do
     %{
       state


### PR DESCRIPTION
Before this PR:

```elixir
iex(3)> {:ok, iex_pid} = ExTTY.start_link(handler: self(), type: :elixir, shell_opts: [])
{:ok, #PID<0.269.0>}
iex(4)> Enum.count(Process.list(), fn pid ->
...(4)>   {:dictionary, d} = Process.info(pid, :dictionary)
...(4)>   d[:"$initial_call"] == {IEx.Evaluator, :init, 5} and pid != self()
...(4)> end)
1
iex(5)> GenServer.stop(iex_pid, :normal, 10_000)
:ok
iex(6)> Enum.count(Process.list(), fn pid ->
...(6)>   {:dictionary, d} = Process.info(pid, :dictionary)
...(6)>   d[:"$initial_call"] == {IEx.Evaluator, :init, 5} and pid != self()
...(6)> end)
1
```

After:

```elixir
iex(1)> {:ok, iex_pid} = ExTTY.start_link(handler: self(), type: :elixir, shell_opts: [])
{:ok, #PID<0.269.0>}
iex(2)> Enum.count(Process.list(), fn pid ->
...(2)>   {:dictionary, d} = Process.info(pid, :dictionary)
...(2)>   d[:"$initial_call"] == {IEx.Evaluator, :init, 5} and pid != self()
...(2)> end)
1
iex(3)> GenServer.stop(iex_pid, :normal, 10_000)
:ok
iex(4)> Enum.count(Process.list(), fn pid ->
...(4)>   {:dictionary, d} = Process.info(pid, :dictionary)
...(4)>   d[:"$initial_call"] == {IEx.Evaluator, :init, 5} and pid != self()
...(4)> end)
0
```

This should address https://github.com/nerves-hub/nerves_hub_link/issues/276