### PR TITLE
Support OTP 28 and 29

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 latest: &latest
-  pattern: "^1.18.*-erlang-27.*$"
+  pattern: "^1.20.*-erlang-29.*$"
 
 jobs:
   build-test:
@@ -52,6 +52,8 @@ workflows:
           matrix:
             parameters:
               tag: [
+                1.20.4-erlang-29.0.6-alpine-3.22.5,
+                1.19.6-erlang-28.5.0.6-alpine-3.22.5,
                 1.18.2-erlang-27.2.4-alpine-3.21.3,
                 1.17.3-erlang-27.2.4-alpine-3.21.3,
                 1.16.3-erlang-26.2.5.2-alpine-3.20.1,

--- a/lib/extty.ex
+++ b/lib/extty.ex
@@ -90,6 +90,15 @@ defmodule ExTTY do
     {:noreply, state}
   end
 
+  # `group` blocks for two seconds waiting on this reply before giving up, and
+  # from OTP 28 the Erlang shell asks for it while starting up, so without an
+  # answer the shell never reaches its first prompt. A pseudo-terminal has no
+  # real stdin or stdout to probe, so answer the way OTP's own `ssh_cli` does.
+  def handle_info({group, :get_terminal_state}, %{group: group} = state) do
+    send(group, {self(), :get_terminal_state, %{stdout: true, stdin: true}})
+    {:noreply, state}
+  end
+
   def handle_info({group, request}, %{group: group} = state) do
     {chars, new_buf} = @tty_cli.io_request(request, state.buf, state.pty, group)
     send_data(chars, state)


### PR DESCRIPTION
`mix test` fails on OTP 28. The Eshell banner arrives and then nothing does, so `that Erlang starts` times out waiting for the `1> ` prompt.

`group` sends the driver a `get_terminal_state` message and blocks for two seconds waiting on the reply. ExTTY has no clause for it, so it falls through to `io_request/4`'s catch-all, which returns no output and sends no reply. Tracing the requests during startup:

```
REQ {:put_chars_sync, :unicode, "Eshell V16.2 ..."}   -> "Eshell V16.2 ..."
REQ :get_terminal_state                              -> ""
```

The message has been in the group protocol since OTP 26, but nothing asked for it during startup until 28. Drop the new clause and OTP 27 still passes.

The reply follows what OTP's own `ssh_cli` sends, which is the closest analogue here: a pseudo-terminal has no real stdin or stdout to probe, so both are reported as a terminal.

This also adds Elixir 1.19/OTP 28 and Elixir 1.20/OTP 29 to the CI matrix and moves the `latest` gate onto the newest of them, so format, docs, hex.build and dialyzer run against the current release rather than 1.18. All six of those checks pass on 1.20/OTP 29, dialyzer included.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
