### PR TITLE
Decode UTF-8 correctly when redrawing the prompt

### DIFF
--- a/src/tty_cli.erl
+++ b/src/tty_cli.erl
@@ -95,7 +95,7 @@ io_request({redraw_prompt, Pbs, Pbs2, {LB, {Bef, Aft}, LA}}, Buf, Tty, _Group) -
                true ->
                     {move_rel, -length(Aft)}
             end,
-    {T, InsertedText} = io_request({insert_chars, unicode:characters_to_binary(Text)}, Cleared, Tty, _Group),
+    {T, InsertedText} = io_request({insert_chars, unicode, unicode:characters_to_binary(Text)}, Cleared, Tty, _Group),
     {M, Moved} = io_request(Moves, InsertedText, Tty, _Group),
     {[ClearLine, T, M], Moved};
 io_request({delete_chars,N}, Buf, Tty, _Group) ->

--- a/test/extty_test.exs
+++ b/test/extty_test.exs
@@ -87,6 +87,35 @@ defmodule ExTTYTest do
     assert_receive {:tty_data, "iex(3)> "}
   end
 
+  test "non-ASCII input survives a prompt redraw" do
+    pid = start_supervised!({ExTTY, [handler: self()]})
+
+    assert_receive {:tty_data, message}
+    assert message =~ "Interactive Elixir"
+
+    # Expect a prompt
+    assert_receive {:tty_data, "iex(1)> "}
+
+    # Disable colors to make tests easier
+    :ok = ExTTY.send_text(pid, "IEx.configure(colors: [enabled: false])\r")
+    assert_receive {:tty_data, "IEx.configure(colors: [enabled: false])\r\n" <> _}
+    assert_receive {:tty_data, ":ok\r\n"}
+    assert_receive {:tty_data, "iex(2)> "}
+
+    # A bare `∞` is a syntax error, so IEx redraws the prompt line. That redraw
+    # used to reach `insert_chars` through the byte-wise clause, which turned
+    # every byte of the UTF-8 encoding into a codepoint of its own: `∞` came
+    # back as `â` followed by the C1 controls U+0088 and U+009E.
+    :ok = ExTTY.send_text(pid, "∞\r")
+
+    output = drain_tty_data()
+
+    assert output =~ "∞"
+    refute output =~ "â"
+    refute output =~ <<0x88::utf8>>
+    refute output =~ <<0x9E::utf8>>
+  end
+
   test "window change acknowledged" do
     pid = start_supervised!({ExTTY, [handler: self()]})
 
@@ -133,5 +162,13 @@ defmodule ExTTYTest do
       end)
 
     assert count == 0
+  end
+
+  defp drain_tty_data(acc \\ []) do
+    receive do
+      {:tty_data, data} -> drain_tty_data([data | acc])
+    after
+      500 -> acc |> Enum.reverse() |> Enum.join()
+    end
   end
 end


### PR DESCRIPTION
Non-ASCII input echoes correctly into a shell over ExTTY, but the moment anything redraws the line it comes back mangled:

```
iex(1)> ∞
iex(1)> â
```

`redraw_prompt` builds a UTF-8 binary with `unicode:characters_to_binary/1` and then hands it to the two-tuple `insert_chars` clause:

```erlang
io_request({insert_chars, Cs}, Buf, Tty, _Group) ->
    insert_chars(bin_to_list(Cs), Buf, Tty);
```

`bin_to_list/1` is `binary_to_list/1`, so `<<226,136,158>>` becomes `[226,136,158]` and each byte ends up a latin-1 character of its own. `∞` returns as `â` followed by the C1 controls U+0088 and U+009E. U+009E is PM, which puts a receiving terminal emulator into a string-consuming state, so the output after it disappears as well; xterm.js reports a parsing error.

Routing the binary to `{insert_chars, unicode, Cs}` decodes it with `unicode:characters_to_list/2` instead.

This file is vendored from OTP's `ssh_cli.erl` and the bug came with it. The identical line is in every OTP 26 and 27, so Erlang's own SSH daemon corrupts non-ASCII on prompt redraw too. OTP 28 rewrote `ssh_cli` on top of `prim_tty`, so it was never fixed in this form upstream.

Found while chasing non-US keyboard support in NervesHub's web console, where German-layout users type `[` with Option-5.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
